### PR TITLE
Updated to not throw exceptions.

### DIFF
--- a/UIColor+HexString.m
+++ b/UIColor+HexString.m
@@ -47,8 +47,7 @@
             blue  = [self colorComponentFrom: colorString start: 6 length: 2];                      
             break;
         default:
-            [NSException raise:@"Invalid color value" format: @"Color value %@ is invalid.  It should be a hex value of the form #RBG, #ARGB, #RRGGBB, or #AARRGGBB", hexString];
-            break;
+            return nil;
     }
     return [UIColor colorWithRed: red green: green blue: blue alpha: alpha];
 }


### PR DESCRIPTION
Crashing an app is not warranted in this situation. Exceptions should really be reserved for...exceptional...cases where continuing the program would be a futile effort.

If an invalid string is passed in, just return `nil`.
