### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # UIColor-HexString
-Easy, Android-compatible hex strings to UIColor. Code from Micah Hainline, found on http://stackoverflow.com/questions/1560081/how-can-i-create-a-uicolor-from-a-hex-string/7180905#7180905. All I've done is package it for Cocoapods.
+Easy, Android-compatible hex strings to UIColor. Code from Micah Hainline, found on http://stackoverflow.com/questions/1560081/how-can-i-create-a-uicolor-from-a-hex-string/7180905#7180905. All I've done is package it for CocoaPods.
 
 Example:
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
